### PR TITLE
fix : change the range of s

### DIFF
--- a/assignment.py
+++ b/assignment.py
@@ -740,7 +740,7 @@ class assignment:
                 cands_in_t = [a for a, b in rotation_poset[t]]
                 reviewers_in_t = [b for a, b in rotation_poset[t]]
                 # Inspect the rotations at the preceding depth
-                for s in rotation_key[d]:
+                for s in range(min(rotation_key[d+1])):
 
                     if (s, t) in edges:
                         if verbose:


### PR DESCRIPTION
I found an additional bug in the function `rotation_digraph`.

What the bug affects:
Some problem instances with n>=20 does not output the exact solution.

The cause:
The edges of the rotation poset are not sufficient due to the overly limited range of s.
This PR will fix the problem. 